### PR TITLE
Oops,forgot this.

### DIFF
--- a/settings.html
+++ b/settings.html
@@ -642,7 +642,7 @@
                                         <option value="de">Deutsch</option>
                                         <option value="fr">Français</option>
                                         <option value="jp">日本語</option>
-                                        <option value="cn">普通话</option>
+                                        <option value="cn">中文</option>
                                         <option value="kr">한국어</option>
                                     </select>
                                 </div>


### PR DESCRIPTION
It is better to translate “Chinese” to "中文".