### PR TITLE
force combo.gif to display above the icon-overlay

### DIFF
--- a/styles/resources.css
+++ b/styles/resources.css
@@ -41,6 +41,9 @@
     position: relative;
     image-rendering: pixelated;
 }
+.icon-active {
+    z-index: 1;
+}
 .ability-image,
 .icon-active,
 .icon-overlay {


### PR DESCRIPTION
Had this tiny change in my custom css for a while and though it was worth opening a pr for as I'm assuming it is the intended look.

![z-index](https://user-images.githubusercontent.com/985941/185826052-b7c3ca14-065d-4747-841b-619f428b28b5.png)